### PR TITLE
Completed the persistance layer of the US map.  Users can now share l…

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,8 +18,8 @@
     <script src='https://code.jquery.com/jquery-1.11.3.min.js'></script>
     <script src="http://code.jquery.com/jquery-1.10.2.min.js"></script>
 	  <script src="http://code.jquery.com/ui/1.10.3/jquery-ui.min.js"></script>
-    <script src="vendor/scripts/jQueryRangeSlider/jquery.mousewheel.min.js"></script>
-    <script src="vendor/scripts/jQueryRangeSlider/jQAllRangeSliders-min.js"></script>
+    <script src="/vendor/scripts/jQueryRangeSlider/jquery.mousewheel.min.js"></script>
+    <script src="/vendor/scripts/jQueryRangeSlider/jQAllRangeSliders-min.js"></script>
     <script src='https://maps.googleapis.com/maps/api/js'></script>
     <script type="text/javascript" src="https://www.google.com/jsapi"></script>
     <script type="text/javascript">
@@ -103,6 +103,7 @@
     </div>
 
     <script src='/vendor/styles/bootstrap/js/bootstrap.js'></script>
+    <script src='/scripts/googleAPIKey.js'></script>
     <script src='/scripts/googleMap.js'></script>
     <script src='/scripts/intlMap.js'></script>
     <script src='/scripts/index.js'></script>

--- a/scripts/googleMap.js
+++ b/scripts/googleMap.js
@@ -1,19 +1,45 @@
 /* The Google Map Object */
-var GoogleMap = function(elementID,dataUrl) {
-  this.model(elementID,dataUrl);
-  this.view();
+var GoogleMap = function(elementID,dataUrl,parameters) {
+  this.model(elementID,dataUrl,parameters);
+  this.view(parameters);
   this.controller();
 };
-GoogleMap.prototype.model = function(elementID,dataUrl) {
+GoogleMap.prototype.model = function(elementID,dataUrl,parameters) {
+  var address = parameters[0];
+  var latitude = 37.09024;
+  var longitude = -95.712891;
+  var zoom = 4;
+  if (address !== null) {
+    var urlAddress = address.replace(/ /g,'+');
+    $.ajax({async: false, url: 'https://maps.googleapis.com/maps/api/geocode/json?address='+urlAddress+'&key='+googleAPIKey}).done(function(data) {
+      if (data.status !== 'ZERO_RESULTS') {
+        latitude = data.results[0].geometry.location.lat;
+        longitude = data.results[0].geometry.location.lng;
+        if (data.results[0].address_components[0].types[0] === 'street_number') {
+          zoom = 17;
+        } else if (data.results[0].address_components[0].types[0] === 'neighborhood') {
+          zoom = 15;
+        } else if (data.results[0].address_components[0].types[0] === 'locality') {
+          zoom = 11;
+        } else if (data.results[0].address_components[0].types[0] === 'administrative_area_level_2') {
+          zoom = 9;
+        } else if (data.results[0].address_components[0].types[0] === 'administrative_area_level_1') {
+          zoom = 7;
+        } else if(data.results[0].address_components[0].types[0] === 'country') {
+          zoom = 4;
+        }
+      }
+    });
+  }
   this.markers = [];
   this.loadMarkers = false;
   this.modelSet = false;
   this.viewSet = false;
   this.currentMarkerWindow = false;
-  var coordinate = {lat:37.09024,lng:-95.712891}; //Coordinate for the USA
+  var coordinate = {lat:latitude,lng:longitude}; //Coordinate for the USA
   var mapOptions = {
     center: coordinate,
-    zoom: 4,
+    zoom: zoom,
     mapTypeId: google.maps.MapTypeId.ROADMAP
   };
   this.map = new google.maps.Map(document.getElementById(elementID),mapOptions);
@@ -37,11 +63,11 @@ GoogleMap.prototype.model = function(elementID,dataUrl) {
     }
   },10);
 };
-GoogleMap.prototype.view = function() {
+GoogleMap.prototype.view = function(parameters) {
   var googleMap = this;
   var loadView = setInterval(function() {
     if (googleMap.getModelSet()) {
-      google.maps.event.addDomListener(window, 'load', googleMap.initMap(googleMap));
+      google.maps.event.addDomListener(window, 'load', googleMap.initMap(googleMap,parameters));
       googleMap.setViewSet(true);
       clearInterval(loadView);
     }
@@ -166,7 +192,7 @@ GoogleMap.prototype.showMapMarker = function(index) {
 GoogleMap.prototype.getMapMarkerVisibility = function(index) {
   return this.markers[index].getVisible();
 };
-GoogleMap.prototype.initMap = function(map) {
+GoogleMap.prototype.initMap = function(map,parameters) {
   var googleMap = map;
   var loadMapMarkers = setInterval(function() {
     if (googleMap.getLoadMarkers()) {
@@ -180,16 +206,18 @@ GoogleMap.prototype.initMap = function(map) {
           googleMap.addMarker(googleMap,coordinate,markerJSON['Incident Date'],markerDate,markerJSON['Killed'],markerJSON['Injured'],markerJSON['hasStreetView']);
         }
         if ((i + 1) >= markersJSON.length) {
-          googleMap.setupDateFilter();
+          googleMap.createDateFilter(parameters[1],parameters[2]);
           clearInterval(loadMapMarkers);
         }
       }
     }
   },10);
 };
-GoogleMap.prototype.setupDateFilter = function() {
+GoogleMap.prototype.createDateFilter = function(min,max) {
   var oldestMarkerDate = '';
   var newestMarkerDate = '';
+  var minMarkerDate = '';
+  var maxMarkerDate = '';
   var mapMarkers = this.getMapMarkers();
   for (i = 0; i < mapMarkers.length; i++) {
     if (oldestMarkerDate === '') {
@@ -241,10 +269,160 @@ GoogleMap.prototype.setupDateFilter = function() {
   newestMarkerDate = newestMarkerDate.split('-');
   oldestMarkerDate = new Date(oldestMarkerDate[0],oldestMarkerDate[1],oldestMarkerDate[2]);
   newestMarkerDate = new Date(newestMarkerDate[0],newestMarkerDate[1],newestMarkerDate[2]);
+  minMarkerDate = oldestMarkerDate;
+  maxMarkerDate = newestMarkerDate;
+  if (min !== null) {
+    var minDate = min;
+    var minMarkerYear = minDate.substring(0,4);
+    var minMarkerMonth = minDate.substring(5,7);
+    var minMarkerDay = minDate.substring(8,minDate.length);
+    minMarkerDate = new Date(parseInt(minMarkerYear),(parseInt(minMarkerMonth)-1),parseInt(minMarkerDay));
+  }
+  if (max !== null) {
+    var maxDate = max;
+    var maxMarkerYear = maxDate.substring(0,4);
+    var maxMarkerMonth = maxDate.substring(5,7);
+    var maxMarkerDay = maxDate.substring(8,maxDate.length);
+    maxMarkerDate = new Date(parseInt(maxMarkerYear),(parseInt(maxMarkerMonth)-1),parseInt(maxMarkerDay));
+  }
   $('#date_range_slider').dateRangeSlider({
-    defaultValues: {min:oldestMarkerDate,max:newestMarkerDate},
+    defaultValues: {min:minMarkerDate,max:maxMarkerDate},
     bounds: {min:oldestMarkerDate,max:newestMarkerDate}
   });
+  var mapMarkers = this.getMapMarkers();
+  var minDate = minMarkerDate;
+  var maxDate = maxMarkerDate;
+  var oldestMarkerYear = minDate.getFullYear();
+  var oldestMarkerMonth = minDate.getMonth();
+  var oldestMarkerDay = minDate.getDate();
+  var newestMarkerYear = maxDate.getFullYear();
+  var newestMarkerMonth = maxDate.getMonth();
+  var newestMarkerDay = maxDate.getDate();
+  for (i = 0; i < mapMarkers.length; i++) {
+    var show = false;
+    var markerYear = mapMarkers[i].date.substring(0,4);
+    var markerMonth = mapMarkers[i].date.substring(5,7);
+    var markerDay = mapMarkers[i].date.substring(7,mapMarkers[i].date.length);
+    var isInRangeOfOldestDate = false;
+    var isInRangeOfNewestDate = false;
+    if (parseInt(markerYear) >= parseInt(oldestMarkerYear)) {
+      if (parseInt(markerYear) === parseInt(oldestMarkerYear)) {
+        if (parseInt(markerMonth) >= parseInt(oldestMarkerMonth)) {
+          if (parseInt(markerMonth) === parseInt(oldestMarkerMonth)) {
+            if (parseInt(markerDay) >= parseInt(oldestMarkerDay)) {
+              isInRangeOfOldestDate = true;
+            }
+          } else {
+            isInRangeOfOldestDate = true;
+          }
+        }
+      } else {
+        isInRangeOfOldestDate = true;
+      }
+    }
+    if (parseInt(markerYear) <= parseInt(newestMarkerYear)) {
+      if (parseInt(markerYear) === parseInt(newestMarkerYear)) {
+        if (parseInt(markerMonth) <= parseInt(newestMarkerMonth)) {
+          if (parseInt(markerMonth) === parseInt(newestMarkerMonth)) {
+            if (parseInt(markerDay) <= parseInt(newestMarkerDay)) {
+              isInRangeOfNewestDate = true;
+            }
+          } else {
+            isInRangeOfNewestDate = true;
+          }
+        }
+      } else {
+        isInRangeOfNewestDate = true;
+      }
+    }
+    if (isInRangeOfOldestDate && isInRangeOfNewestDate) {
+      show = true;
+    }
+    if (!show) {
+      if (this.getMapMarkerVisibility(i)) {
+        this.hideMapMarker(i);
+      }
+    } else {
+      if (!this.getMapMarkerVisibility(i)) {
+        this.showMapMarker(i);
+      }
+    }
+  }
+};
+GoogleMap.prototype.setupDateFilter = function(min,max) {
+  var oldestMarkerDate = '';
+  var newestMarkerDate = '';
+  var minMarkerDate = '';
+  var maxMarkerDate = '';
+  var mapMarkers = this.getMapMarkers();
+  for (i = 0; i < mapMarkers.length; i++) {
+    if (oldestMarkerDate === '') {
+      oldestMarkerDate = mapMarkers[i].date.toString();
+    }
+    if (newestMarkerDate === '') {
+      newestMarkerDate = mapMarkers[i].date.toString();
+    }
+    var markerYear = mapMarkers[i].date.substring(0,4);
+    var markerMonth = mapMarkers[i].date.substring(5,7);
+    var markerDay = mapMarkers[i].date.substring(8,mapMarkers[i].date.length);
+    var oldestMarkerYear = oldestMarkerDate.substring(0,4);
+    var oldestMarkerMonth = oldestMarkerDate.substring(5,7);
+    var oldestMarkerDay = oldestMarkerDate.substring(8,oldestMarkerDate.length);
+    var newestMarkerYear = newestMarkerDate.substring(0,4);
+    var newestMarkerMonth = newestMarkerDate.substring(5,7);
+    var newestMarkerDay = newestMarkerDate.substring(8,newestMarkerDate.length);
+    var oldestDate = false;
+    var oldestYear = false;
+    var oldestMonth = false;
+    var oldestDay = false;
+    var newestDate = false;
+    var newestYear = false;
+    var newestMonth = false;
+    var newestDay = false;
+    if (markerYear <= oldestMarkerYear) {
+      oldestYear = true;
+    } else if (markerYear >= newestMarkerYear) {
+      newestYear = true;
+    }
+    if (markerMonth <= oldestMarkerMonth) {
+      oldestMonth = true;
+    } else if (markerMonth >= newestMarkerMonth) {
+      newestMonth = true;
+    }
+    if (markerDay <= oldestMarkerDay) {
+      oldestDay = true;
+    } else if (markerDay >= newestMarkerDay) {
+      newestDay = true;
+    }
+    if (oldestYear && oldestMonth && oldestDay) {
+      oldestMarkerDate = mapMarkers[i].date.toString();
+    }
+    if (newestYear && newestMonth && newestDay) {
+      newestMarkerDate = mapMarkers[i].date.toString();
+    }
+  }
+  oldestMarkerDate = oldestMarkerDate.split('-');
+  newestMarkerDate = newestMarkerDate.split('-');
+  oldestMarkerDate = new Date(oldestMarkerDate[0],oldestMarkerDate[1],oldestMarkerDate[2]);
+  newestMarkerDate = new Date(newestMarkerDate[0],newestMarkerDate[1],newestMarkerDate[2]);
+  minMarkerDate = oldestMarkerDate;
+  maxMarkerDate = newestMarkerDate;
+  if (min !== null) {
+    var minDate = min;
+    var minMarkerYear = minDate.substring(0,4);
+    var minMarkerMonth = minDate.substring(5,7);
+    var minMarkerDay = minDate.substring(8,minDate.length);
+    minMarkerDate = new Date(parseInt(minMarkerYear),(parseInt(minMarkerMonth)-1),parseInt(minMarkerDay));
+  }
+  if (max !== null) {
+    var maxDate = max;
+    var maxMarkerYear = maxDate.substring(0,4);
+    var maxMarkerMonth = maxDate.substring(5,7);
+    var maxMarkerDay = maxDate.substring(8,maxDate.length);
+    maxMarkerDate = new Date(parseInt(maxMarkerYear),(parseInt(maxMarkerMonth)-1),parseInt(maxMarkerDay));
+  }
+  $('#date_range_slider').dateRangeSlider('values',minMarkerDate,maxMarkerDate);
+  $('#date_range_slider').dateRangeSlider('bounds',oldestMarkerDate,newestMarkerDate);
 };
 GoogleMap.prototype.setupFilterActions = function(map) {
   var googleMap = map;
@@ -258,6 +436,24 @@ GoogleMap.prototype.setupFilterActions = function(map) {
     var newestMarkerYear = maxDate.getFullYear();
     var newestMarkerMonth = maxDate.getMonth();
     var newestMarkerDay = maxDate.getDate();
+    var oldestMarkerMonthString = oldestMarkerMonth + 1;
+    var oldestMarkerDayString = oldestMarkerDay;
+    if (oldestMarkerMonthString < 10) {
+      oldestMarkerMonthString = ('0' + oldestMarkerMonthString).toString();
+    }
+    if (oldestMarkerDayString < 10) {
+      oldestMarkerDayString = ('0' + oldestMarkerDayString).toString();
+    }
+    var newestMarkerMonthString = newestMarkerMonth + 1;
+    var newestMarkerDayString = newestMarkerDay;
+    if (newestMarkerMonthString < 10) {
+      newestMarkerMonthString = ('0' + newestMarkerMonthString).toString();
+    }
+    if (newestMarkerDayString < 10) {
+      newestMarkerDayString = ('0' + newestMarkerDayString).toString();
+    }
+    var minDateString = (oldestMarkerYear + '-' + oldestMarkerMonthString + '-' + oldestMarkerDayString).toString();
+    var maxDateString = (newestMarkerYear + '-' + newestMarkerMonthString + '-' + newestMarkerDayString).toString();
     for (i = 0; i < mapMarkers.length; i++) {
       var show = false;
       var markerYear = mapMarkers[i].date.substring(0,4);
@@ -308,13 +504,101 @@ GoogleMap.prototype.setupFilterActions = function(map) {
         }
       }
     }
+    var url = window.location.href;
+    var lastSlash = window.location.href.lastIndexOf('/');
+    var queryString = '';
+    if (lastSlash <= 8) {
+      var baseUrl = window.location.href;
+      var dateRangeString = (minDateString + '+' + maxDateString).toString();
+      dateRangeString = dateRangeString.replace(/[a-z]/gi,'');
+      dateRangeString = ('Date-Range=' + dateRangeString);
+      window.location.href = baseUrl + '/us/' + dateRangeString;
+    } else if (window.location.href.substring((lastSlash + 1),(lastSlash+3)) === 'us') {
+      var baseUrl = window.location.href.substring(0,lastSlash+3);
+      queryString = window.location.href.substring((lastSlash + 1),window.location.href.length);
+      var locationString = '';
+      var dateRangeString = '';
+      queryString = queryString.split('&');
+      if (queryString[0].indexOf('Location=') > -1) {
+        locationString = queryString[0].substring(9,queryString[0].length);
+      } else if (queryString[0].indexOf('Date-Range=') > -1) {
+        dateRangeString = queryString[0].substring(11,queryString[0].length);
+      }
+      if (queryString.length > 1) {
+        if (queryString[1].indexOf('Location=') > -1) {
+          locationString = queryString[1].substring(9,queryString[1].length);
+        } else if (queryString[1].indexOf('Date-Range=') > -1) {
+          dateRangeString = queryString[1].substring(11,queryString[1].length);
+        }
+      }
+      if (locationString === '') {
+        locationString = null;
+      } else {
+        locationString = locationString.replace(/[^a-z0-9+-]+/gi,'');
+      }
+      if (dateRangeString === '') {
+        dateRangeString = null;
+      } else {
+        dateRangeString = dateRangeString.replace(/[a-z]/gi,'');
+      }
+      dateRangeString = (minDateString + '+' + maxDateString).toString();
+      dateRangeString = dateRangeString.replace(/[a-z]/gi,'');
+      dateRangeString = ('Date-Range=' + dateRangeString);
+      if (locationString !== null) {
+        locationString = ('Location=' + locationString);
+      }
+      if (locationString !== null) {
+        window.location.href = baseUrl + '/' + locationString + '&' + dateRangeString;
+      } else {
+        window.location.href = baseUrl + '/' + dateRangeString;
+      }
+    } else {
+      var baseUrl = window.location.href.substring(0,lastSlash);
+      queryString = window.location.href.substring((lastSlash + 1),window.location.href.length);
+      var locationString = '';
+      var dateRangeString = '';
+      queryString = queryString.split('&');
+      if (queryString[0].indexOf('Location=') > -1) {
+        locationString = queryString[0].substring(9,queryString[0].length);
+      } else if (queryString[0].indexOf('Date-Range=') > -1) {
+        dateRangeString = queryString[0].substring(11,queryString[0].length);
+      }
+      if (queryString.length > 1) {
+        if (queryString[1].indexOf('Location=') > -1) {
+          locationString = queryString[1].substring(9,queryString[1].length);
+        } else if (queryString[1].indexOf('Date-Range=') > -1) {
+          dateRangeString = queryString[1].substring(11,queryString[1].length);
+        }
+      }
+      if (locationString === '') {
+        locationString = null;
+      } else {
+        locationString = locationString.replace(/[^a-z0-9+-]+/gi,'');
+      }
+      if (dateRangeString === '') {
+        dateRangeString = null;
+      } else {
+        dateRangeString = dateRangeString.replace(/[a-z]/gi,'');
+      }
+      dateRangeString = (minDateString + '+' + maxDateString).toString();
+      dateRangeString = dateRangeString.replace(/[a-z]/gi,'');
+      dateRangeString = ('Date-Range=' + dateRangeString);
+      if (locationString !== null) {
+        locationString = ('Location=' + locationString);
+      }
+      if (locationString !== null) {
+        window.location.href = baseUrl + '/' + locationString + '&' + dateRangeString;
+      } else {
+        window.location.href = baseUrl + '/' + dateRangeString;
+      }
+    }
   });
   $('#united_states_map_location_input').keyup(function(event){
     if(event.keyCode == 13) {
       var value = $('#united_states_map_location_input').val();
       if (value !== '') {
         var urlAddress = value.replace(/ /g,'+');
-        $.ajax({url: 'https://maps.googleapis.com/maps/api/geocode/json?address='+urlAddress+'&key=AIzaSyB1KIj0tt4j-o4BIhayALx19omN1dJJm7E'}).done(function(data) {
+        $.ajax({url: 'https://maps.googleapis.com/maps/api/geocode/json?address='+urlAddress+'&key='+googleAPIKey}).done(function(data) {
           if (data.status !== 'ZERO_RESULTS') {
             var latitude = data.results[0].geometry.location.lat;
             var longitude = data.results[0].geometry.location.lng;
@@ -334,9 +618,129 @@ GoogleMap.prototype.setupFilterActions = function(map) {
               zoom = 4;
             }
             googleMap.map.setZoom(zoom);
+            var url = window.location.href;
+            var lastSlash = window.location.href.lastIndexOf('/');
+            var queryString = '';
+            if (lastSlash <= 8) {
+              alert('0');
+              locationString = urlAddress.replace(/[^a-z0-9+-]+/gi,'');
+              locationString = ('Location=' + locationString);
+              window.location.href = baseUrl + locationString;
+            } else if (window.location.href.substring((lastSlash + 1),(lastSlash+3)) === 'us') {
+              alert('1');
+              var baseUrl = window.location.href.substring(0,lastSlash+3);
+              queryString = window.location.href.substring((lastSlash + 1),window.location.href.length);
+              var locationString = '';
+              var dateRangeString = '';
+              queryString = queryString.split('&');
+              if (queryString[0].indexOf('Location=') > -1) {
+                locationString = queryString[0].substring(9,queryString[0].length);
+              } else if (queryString[0].indexOf('Date-Range=') > -1) {
+                dateRangeString = queryString[0].substring(11,queryString[0].length);
+              }
+              if (queryString.length > 1) {
+                if (queryString[1].indexOf('Location=') > -1) {
+                  locationString = queryString[1].substring(9,queryString[1].length);
+                } else if (queryString[1].indexOf('Date-Range=') > -1) {
+                  dateRangeString = queryString[1].substring(11,queryString[1].length);
+                }
+              }
+              if (locationString === '') {
+                locationString = null;
+              } else {
+                locationString = locationString.replace(/[^a-z0-9+-]+/gi,'');
+              }
+              if (dateRangeString === '') {
+                dateRangeString = null;
+              } else {
+                dateRangeString = dateRangeString.replace(/[a-z]/gi,'');
+              }
+              locationString = urlAddress.replace(/[^a-z0-9+-]+/gi,'');
+              locationString = ('Location=' + locationString);
+              if (dateRangeString !== null) {
+                dateRangeString = ('Date-Range=' + dateRangeString);
+              }
+              if (dateRangeString !== null) {
+                window.location.href = baseUrl + '/' + locationString + '&' + dateRangeString;
+              } else {
+                window.location.href = baseUrl + '/' + locationString;
+              }
+            } else {
+              alert('2');
+              var baseUrl = window.location.href.substring(0,lastSlash - 3);
+              queryString = window.location.href.substring((lastSlash + 1),window.location.href.length);
+              var locationString = '';
+              var dateRangeString = '';
+              queryString = queryString.split('&');
+              if (queryString[0].indexOf('Location=') > -1) {
+                locationString = queryString[0].substring(9,queryString[0].length);
+              } else if (queryString[0].indexOf('Date-Range=') > -1) {
+                dateRangeString = queryString[0].substring(11,queryString[0].length);
+              }
+              if (queryString.length > 1) {
+                if (queryString[1].indexOf('Location=') > -1) {
+                  locationString = queryString[1].substring(9,queryString[1].length);
+                } else if (queryString[1].indexOf('Date-Range=') > -1) {
+                  dateRangeString = queryString[1].substring(11,queryString[1].length);
+                }
+              }
+              if (locationString === '') {
+                locationString = null;
+              } else {
+                locationString = locationString.replace(/[^a-z0-9+-]+/gi,'');
+              }
+              if (dateRangeString === '') {
+                dateRangeString = null;
+              } else {
+                dateRangeString = dateRangeString.replace(/[a-z]/gi,'');
+              }
+              locationString = urlAddress.replace(/[^a-z0-9+-]+/gi,'');
+              alert('Location: '+locationString);
+              locationString = ('Location=' + locationString);
+              if (dateRangeString !== null) {
+                dateRangeString = ('Date-Range=' + dateRangeString);
+              }
+              if (dateRangeString !== null) {
+                window.location.href = baseUrl + '/us/' + locationString + '&' + dateRangeString;
+              } else {
+                window.location.href = baseUrl + '/us/' + locationString;
+              }
+            }
           }
         });
       }
     }
   });
+};
+GoogleMap.prototype.refresh = function() {
+  google.maps.event.trigger(this.map, 'resize');
+  this.map.setZoom(4);
+  this.map.setCenter(new google.maps.LatLng(37.09024,-95.712891));
+};
+GoogleMap.prototype.centerMapOnAddress = function(address) {
+  if (address !== '') {
+    var urlAddress = address.replace(/ /g,'+');
+    $.ajax({async: false, url: 'https://maps.googleapis.com/maps/api/geocode/json?address='+urlAddress+'&key='+googleAPIKey}).done(function(data) {
+      if (data.status !== 'ZERO_RESULTS') {
+        var latitude = data.results[0].geometry.location.lat;
+        var longitude = data.results[0].geometry.location.lng;
+        this.map.setCenter(new google.maps.LatLng(latitude,longitude));
+        var zoom = 0;
+        if (data.results[0].address_components[0].types[0] === 'street_number') {
+          zoom = 17;
+        } else if (data.results[0].address_components[0].types[0] === 'neighborhood') {
+          zoom = 15;
+        } else if (data.results[0].address_components[0].types[0] === 'locality') {
+          zoom = 11;
+        } else if (data.results[0].address_components[0].types[0] === 'administrative_area_level_2') {
+          zoom = 9;
+        } else if (data.results[0].address_components[0].types[0] === 'administrative_area_level_1') {
+          zoom = 7;
+        } else if(data.results[0].address_components[0].types[0] === 'country') {
+          zoom = 4;
+        }
+        this.map.setZoom(zoom);
+      }
+    });
+  }
 };

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -1,6 +1,5 @@
 var index = {};
 localStorage.setItem('currentMap', '#united_states_map');
-
 index.chooseActiveMap = function(){
   var currentMap = localStorage.getItem('currentMap');
   if(currentMap === '#united_states_map'){
@@ -10,22 +9,19 @@ index.chooseActiveMap = function(){
     $('#inter').addClass('active').siblings().removeClass('active');
   }
 };
-
 index.removeText = function(event) {
   event.preventDefault();
   $('#topLayerText').hide();
   $('.overlay').fadeOut(1000);
   index.chooseActiveMap();
 };
-
 index.modal = function() {
   $('#topLayerText').show();
   $('.container.takeActionModal').hide();
   $('.container.textOver').fadeIn();
   $('.overlay').fadeIn(1000);
 };
-
-index.googleMap = function() {
+index.unitedStatesMap = function() {
   localStorage.setItem('currentMap', '#united_states_map');
   $('#topLayerText').hide();
   $('#imap').hide();
@@ -34,24 +30,102 @@ index.googleMap = function() {
   $('#united_states_map_filters').show();
   $('.overlay').fadeOut(1000);
   index.chooseActiveMap();
+  var parameters = [null,null,null];
+  if (index.unitedStatesGoogleMap === undefined) {
+    index.unitedStatesGoogleMap = new GoogleMap('united_states_map','../data/gunViolenceArchive.json',parameters);
+  } else {
+    index.unitedStatesGoogleMap.refresh();
+    index.unitedStatesGoogleMap.setupDateFilter(null,null);
+    index.unitedStatesGoogleMap.centerMapOnAddress('United+States');
+  }
 };
-
+index.unitedStatesSpecificMap = function() {
+  localStorage.setItem('currentMap', '#united_states_map');
+  $('#topLayerText').hide();
+  $('#imap').hide();
+  $('.intlMapToggle').hide();
+  $('#united_states_map').show();
+  $('#united_states_map_filters').show();
+  $('.overlay').fadeOut(1000);
+  var lastSlash = window.location.href.lastIndexOf('/');
+  var queryString = window.location.href.substring((lastSlash + 1),window.location.href.length);
+  var locationString = '';
+  var dateRangeString = '';
+  queryString = queryString.split('&');
+  if (queryString[0].indexOf('Location=') > -1) {
+    locationString = queryString[0].substring(9,queryString[0].length);
+  } else if (queryString[0].indexOf('Date-Range=') > -1) {
+    dateRangeString = queryString[0].substring(11,queryString[0].length);
+  }
+  if (queryString.length > 1) {
+    if (queryString[1].indexOf('Location=') > -1) {
+      locationString = queryString[1].substring(9,queryString[1].length);
+    } else if (queryString[1].indexOf('Date-Range=') > -1) {
+      dateRangeString = queryString[1].substring(11,queryString[1].length);
+    }
+  }
+  if (locationString === '') {
+    locationString = null;
+  } else {
+    locationString = locationString.replace(/[^a-z0-9+-]+/gi,'');
+  }
+  if (dateRangeString === '') {
+    dateRangeString = null;
+  } else {
+    dateRangeString = dateRangeString.replace(/[a-z]/gi,'');
+  }
+  var centeredMapAddress = locationString;
+  var markerDates = '';
+  if (dateRangeString !== null) {
+    markerDates = dateRangeString.split('+');
+  }
+  var markerMinDate = '';
+  var markerMaxDate = '';
+  if (markerDates.length === 2) {
+    markerMinDate = markerDates[0].split('-');
+    markerMaxDate = markerDates[1].split('-');
+  }
+  for (i = 0; i < markerMinDate.length; i++) {
+    markerMinDate[i] = markerMinDate[i].replace(/\W+/g,'');
+  }
+  for (i = 0; i < markerMaxDate.length; i++) {
+    markerMaxDate[i] = markerMaxDate[i].replace(/\W+/g,'');
+  }
+  if (markerMinDate.length !== 3) {
+    markerMinDate = null;
+  }
+  if (markerMaxDate.length !== 3) {
+    markerMaxDate = null;
+  }
+  if (markerMinDate !== null) {
+    markerMinDate = (markerMinDate[0]+'-'+markerMinDate[1]+'-'+markerMinDate[2]).toString();
+  }
+  if (markerMaxDate !== null) {
+    markerMaxDate = (markerMaxDate[0]+'-'+markerMaxDate[1]+'-'+markerMaxDate[2]).toString();
+  }
+  var parameters = [centeredMapAddress,markerMinDate,markerMaxDate];
+  index.chooseActiveMap();
+  if (index.unitedStatesGoogleMap === undefined) {
+    index.unitedStatesGoogleMap = new GoogleMap('united_states_map','../data/gunViolenceArchive.json',parameters);
+    index.unitedStatesGoogleMap.centerMapOnAddress(parameters[0]);
+  } else {
+    index.unitedStatesGoogleMap.refresh();
+    index.unitedStatesGoogleMap.setupDateFilter(parameters[1],parameters[2]);
+    index.unitedStatesGoogleMap.centerMapOnAddress(parameters[0]);
+  }
+};
 index.iMapChange = function() {
   index.iMap.changeFilter();
-
   $.getJSON('data/intlData.json', function(data) {
     var arr = [['location_name', 'mean']];
-
     data.forEach(function(element) {
       if(element['unit'] == index.iMap.filters[index.iMap.currentFilter])
         arr.push([element['location_name'], Number(element['mean'])]);
     });
-
     index.iMap.render(google.visualization.arrayToDataTable(arr));
   });
 };
-
-index.intlMap = function() {
+index.internationalMap = function() {
   localStorage.setItem('currentMap', '#imap');
   $('#topLayerText').hide();
   $('#united_states_map').hide();
@@ -60,15 +134,12 @@ index.intlMap = function() {
   $('.intlMapToggle').show();
   $('.overlay').fadeOut(1000);
   index.chooseActiveMap();
-
   $.getJSON('data/intlData.json', function(data) {
     var arr = [['location_name', index.iMap.filters[index.iMap.currentFilter]]];
-
     data.forEach(function(element) {
       if(element['unit'] == index.iMap.filters[index.iMap.currentFilter])
         arr.push([element['location_name'], Number(element['mean'])]);
     });
-
     index.iMap.render(google.visualization.arrayToDataTable(arr));
   });
 };
@@ -80,20 +151,10 @@ index.takeAction = function() {
   $('.overlay').fadeIn(1000);
   $('#takeAction').addClass('active');
   $('#takeAction').siblings().removeClass('active');
-  $('#international_map').hide();
-  $('#united_states_map').hide();
-  $('#united_states_map_filters').hide();
 };
 $(function() {
-
-  index.unitedStatesGoogleMap = new GoogleMap('united_states_map','../data/gunViolenceArchive.json');
   index.iMap = new IntlMap();
-
-  $('.intlMapToggle').hide();
-
   $('#continue').on('click', index.removeText);
-
   $('div.overlay').on('click', index.removeText);
-
   $('#returnToMap').on('click', index.removeText);
 });

--- a/scripts/router.js
+++ b/scripts/router.js
@@ -1,3 +1,4 @@
+page('/us/*', index.unitedStatesSpecificMap);
 page('/us', index.unitedStatesMap);
 page('/intl', index.internationalMap);
 


### PR DESCRIPTION
Completed the persistence layer of the US maps filter options.  Users can now share links generated in the address bar when they change the date range and/or perform a location search.  These links can specify, no data range or location, a data range and no location, a location and no data range, and a data range and location.  The back and forward buttons also work between map filter alterations, so for example if a user searches for 'Seattle WA' in the location search then afterwards searches for 'Chicago' the user is able to navigate back to the 'Seattle WA' location search using the browser's back button and from there navigate again to the 'Chicago' location search using the browser's forward button.